### PR TITLE
Update cleff-plugin for ghc9.4.

### DIFF
--- a/cleff-plugin/cleff-plugin.cabal
+++ b/cleff-plugin/cleff-plugin.cabal
@@ -54,10 +54,10 @@ library
       UnicodeSyntax
   ghc-options: -Wall -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wno-unticked-promoted-constructors -Wpartial-fields -Wunused-type-patterns -Wmissing-export-lists
   build-depends:
-      base >=4.12 && <4.17
+      base >=4.12 && <4.18
     , cleff >=0.1 && <0.4
     , containers >=0.5 && <0.7
-    , ghc >=8.6 && <9.3
+    , ghc >=8.6 && <9.4.6
     , ghc-tcplugins-extra >=0.3 && <0.5
   if impl(ghc >= 8.8)
     ghc-options: -Wmissing-deriving-strategies


### PR DESCRIPTION
Hi. This patch shows the necessary changes need to get the `cleff-plugin` to work for ghc9.4.

I took the changes from:
https://github.com/polysemy-research/polysemy/commit/f9b19c022b0a5c18e473b0127172b6a3c4f94be2#diff-334e6203f5c3450b1654c9645089b2cc41323751b40d4ebc111b5a1b546c3407

Seems like for a full integration, you'd need to write the CPP pragmas.